### PR TITLE
Add support for XDP UPS pods v2

### DIFF
--- a/ups/templates/pod.yaml
+++ b/ups/templates/pod.yaml
@@ -1,4 +1,4 @@
-{{ $count := (tpl .Values.numberOfUpStacks . | int) - (len .Values.xdpUpsInterfaces) }}
+{{- $count := (tpl .Values.numberOfUpStacks . | int) -}}
 {{- range untilStep 0 $count 1 }}
 apiVersion: v1
 kind: Pod

--- a/ups/templates/pod.yaml
+++ b/ups/templates/pod.yaml
@@ -1,4 +1,4 @@
-{{ $count := (tpl .Values.numberOfUpStacks . | int) }}
+{{ $count := (tpl .Values.numberOfUpStacks . | int) - (len .Values.xdpUpsInterfaces) }}
 {{- range untilStep 0 $count 1 }}
 apiVersion: v1
 kind: Pod
@@ -83,12 +83,14 @@ spec:
               fieldPath: metadata.name
         - name: __APPID
           value: ups_{{ . }}
+        - name: __APPNAME
+          value: ups
         - name: NATS_SERVICE_URL
-          value: nats://{{ tpl $.Values.nats.url $ }}:{{ tpl $.Values.nats.port $ }}
+          value: "nats://{{ tpl $.Values.nats.url $ }}:{{ tpl $.Values.nats.port $ }}"
         - name: BOOTSTRAP_FILENAME
-          value: {{ $.Values.bootstrapFile }}
+          value: "{{ $.Values.bootstrapFile }}"
         - name: JAEGER_AGENT_HOST
-          value: {{ tpl $.Values.jaegerAgentHost $ }}
+          value: "{{ tpl $.Values.jaegerAgentHost $ }}"
         {{- if $.Values.extraEnvs }}
         {{ toYaml $.Values.extraEnvs | nindent 8 }}
         {{- end }}

--- a/ups/templates/xdp-pod.yaml
+++ b/ups/templates/xdp-pod.yaml
@@ -30,12 +30,16 @@ spec:
         {{- toYaml $.Values.securityContext | nindent 8 }}
       image: "{{ $.Values.xdp.image.repository }}:{{ tpl $.Values.image.tag $ | default $.Chart.AppVersion }}"
       imagePullPolicy: {{ $.Values.image.pullPolicy }}
-      command:
-      - /bin/bash
-      - "-c"
-      - |
-        ip link set dev $IFNAME xdpgeneric off
-        {{ $.Values.xdp.cmd }} {{- if $.Values.xdp.args }}{{ range $.Values.xdp.args }} {{ .name }} {{ tpl .value $ }}{{ end }}{{- end }}
+      {{- if $.Values.xdp.cmd }}
+      command: "{{ $.Values.xdp.cmd }}"
+      {{- end }}
+      {{- if $.Values.xdp.args }}
+      args:
+      {{- range $.Values.xdp.args }}
+        - "{{ .name }}"
+        - "{{ tpl .value $ }}"
+      {{- end }}
+      {{- end }}
       env:
         - name: HOSTMODE
           value: "true"
@@ -62,10 +66,6 @@ spec:
           subPath: "bootstrap.txt"
       resources:
         {{- toYaml $.Values.resources | nindent 8 }}
-      lifecycle:
-        preStop:
-          exec:
-            command: [ '/bin/sh', '-c', 'pkill -15 -e {{ $.Values.xdp.cmd | trimPrefix "./" | trimSuffix ".exe" | trunc 15  }}' ]
   {{- if $xdpUpsInterface.nodeName }}
   nodeName: {{ $xdpUpsInterface.nodeName }}
   {{- end }}

--- a/ups/templates/xdp-pod.yaml
+++ b/ups/templates/xdp-pod.yaml
@@ -1,3 +1,7 @@
+{{- if and (gt (len .Values.xdp.interfaces) 0) (gt (tpl .Values.numberOfUpStacks . | int) 0) -}}
+{{- fail "UPS XDP Interfaces can only be specified if numberOfUpStacks is set to 0" -}}
+{{- end -}}
+
 {{- range $index, $xdpUpsInterface := .Values.xdp.interfaces }}
 apiVersion: v1
 kind: Pod

--- a/ups/templates/xdp-pod.yaml
+++ b/ups/templates/xdp-pod.yaml
@@ -1,0 +1,87 @@
+{{- range $index, $xdpUpsInterface := .Values.xdp.interfaces }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "acc-common.fullname" $ }}-xdp-{{ $index }}"
+  {{- with $.Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "acc-common.labels.5g" $ | nindent 4 }}
+    up-stack-id: "xdp-{{ $index }}"
+spec:
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  {{- with $.Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  serviceAccountName: {{ include "acc-common.serviceAccountName" $ }}
+  securityContext:
+    {{- toYaml $.Values.podSecurityContext | nindent 4 }}
+  containers:
+    - name: "{{ $.Chart.Name }}-xdp-{{ $index }}"
+      securityContext:
+        {{- toYaml $.Values.securityContext | nindent 8 }}
+      image: "{{ $.Values.xdp.image.repository }}:{{ tpl $.Values.image.tag $ | default $.Chart.AppVersion }}"
+      imagePullPolicy: {{ $.Values.image.pullPolicy }}
+      command:
+      - /bin/bash
+      - "-c"
+      - |
+        ip link set dev $IFNAME xdpgeneric off
+        {{ $.Values.xdp.cmd }} {{- if $.Values.xdp.args }}{{ range $.Values.xdp.args }} {{ .name }} {{ tpl .value $ }}{{ end }}{{- end }}
+      env:
+        - name: HOSTMODE
+          value: "true"
+        - name: GTP_IP
+          value: "{{ $xdpUpsInterface.address }}"
+        - name: "IFNAME"
+          value: "{{ $xdpUpsInterface.name }}"
+        - name: MTU_SIZE
+          value: "{{ $xdpUpsInterface.mtu | default 1460 }}"
+        - name: __APPID
+          value: xdp-ups_{{ $index }}
+        - name: __APPNAME
+          value: xdp-ups
+        - name: NATS_SERVICE_URL
+          value: "nats://{{ tpl $.Values.nats.url $ }}:{{ tpl $.Values.nats.port $ }}"
+        - name: BOOTSTRAP_FILENAME
+          value: "{{ $.Values.bootstrapFile }}"
+        {{- if $.Values.extraEnvs }}
+        {{ toYaml $.Values.extraEnvs | nindent 8 }}
+        {{- end }}
+      volumeMounts:
+        - name: {{ include "acc-common.fullname" $ }}-bootstrap
+          mountPath: {{ $.Values.bootstrapFile }}
+          subPath: "bootstrap.txt"
+      resources:
+        {{- toYaml $.Values.resources | nindent 8 }}
+      lifecycle:
+        preStop:
+          exec:
+            command: [ '/bin/sh', '-c', 'pkill -15 -e {{ $.Values.xdp.cmd | trimPrefix "./" | trimSuffix ".exe" | trunc 15  }}' ]
+  {{- if or ($.Values.nodeSelector) (eq (tpl $.Values.draxNodeSelectorEnabled $) "true") }}
+  nodeSelector:
+    {{ if $.Values.nodeSelector }}
+      {{- toYaml $.Values.nodeSelector | nindent 4 }}
+    {{ end }}
+    {{ if eq (tpl $.Values.draxNodeSelectorEnabled $) "true" }}
+      {{- tpl (toYaml $.Values.draxNodeSelector) $ | nindent 4 }}
+    {{ end }}
+  {{- end }}
+  {{- with $.Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  volumes:
+    - name: {{ include "acc-common.fullname" $ }}-bootstrap
+      configMap:
+        name: {{ include "acc-common.fullname" $ }}-bootstrap
+---
+{{- end }}

--- a/ups/templates/xdp-pod.yaml
+++ b/ups/templates/xdp-pod.yaml
@@ -66,14 +66,23 @@ spec:
         preStop:
           exec:
             command: [ '/bin/sh', '-c', 'pkill -15 -e {{ $.Values.xdp.cmd | trimPrefix "./" | trimSuffix ".exe" | trunc 15  }}' ]
-  {{- if or ($.Values.nodeSelector) (eq (tpl $.Values.draxNodeSelectorEnabled $) "true") }}
+  {{- if $xdpUpsInterface.nodeName }}
+  nodeName: {{ $xdpUpsInterface.nodeName }}
+  {{- end }}
+  {{- if $xdpUpsInterface.nodeSelectorOverride }}
   nodeSelector:
-    {{ if $.Values.nodeSelector }}
+    {{- toYaml $xdpUpsInterface.nodeSelectorOverride | nindent 4 }}
+  {{- else if or (or $xdpUpsInterface.nodeSelector ($.Values.nodeSelector)) (eq (tpl $.Values.draxNodeSelectorEnabled $) "true") }}
+  nodeSelector:
+    {{- if $.Values.nodeSelector }}
       {{- toYaml $.Values.nodeSelector | nindent 4 }}
-    {{ end }}
-    {{ if eq (tpl $.Values.draxNodeSelectorEnabled $) "true" }}
+    {{- end }}
+    {{- if $xdpUpsInterface.nodeSelector }}
+      {{- toYaml $xdpUpsInterface.nodeSelector | nindent 4 }}
+    {{- end }}
+    {{- if eq (tpl $.Values.draxNodeSelectorEnabled $) "true" }}
       {{- tpl (toYaml $.Values.draxNodeSelector) $ | nindent 4 }}
-    {{ end }}
+    {{- end }}
   {{- end }}
   {{- with $.Values.affinity }}
   affinity:

--- a/ups/values.yaml
+++ b/ups/values.yaml
@@ -16,8 +16,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Application Settings
-# cmd: "__APPNAME=amfController ./amfControllerAppl.exe"
-cmd: "./upsAppl.exe"
+cmd: "./entrypoint.sh"
 
 testing:
   value: "${GTP_IP}"
@@ -66,9 +65,8 @@ xdp:
   #   mtu: 1460 # optional, default 1460
   image:
     repository: accelleran/xdpupsappl
-  # Application Settings
-  cmd: "./xdpUpsAppl.exe"
 
+  cmd: null # Use image entrypoint by default
   args:
     - name: "--downlink"
       value: "$GTP_IP"

--- a/ups/values.yaml
+++ b/ups/values.yaml
@@ -50,6 +50,24 @@ args:
   - name: "--bind"
     value: "$POD_IP"
 
+xdp:
+  interfaces: []
+  # - name: "eth0"
+  #   address: "127.0.0.1"
+  #   mtu: 1460 # optional, default 1460
+  image:
+    repository: accelleran/xdpupsappl
+  # Application Settings
+  cmd: "./xdpUpsAppl.exe"
+
+  args:
+    - name: "--downlink"
+      value: "$GTP_IP"
+    - name: "--uplink"
+      value: "$GTP_IP"
+    - name: "--bind"
+      value: "$GTP_IP"
+
 # NATS Settings
 nats:
   # URL of NATS
@@ -68,8 +86,6 @@ bootstrapFile: /home/accelleran/5G/bootstrap.txt
 jaegerAgentHost: "ric-jaeger-agent"
 
 extraEnvs:
-  - name: __APPNAME
-    value: ups
 #  - name: example_env_name
 #    value: example_env_value
 #  - name: ex1

--- a/ups/values.yaml
+++ b/ups/values.yaml
@@ -54,6 +54,15 @@ xdp:
   interfaces: []
   # - name: "eth0"
   #   address: "127.0.0.1"
+  #   # nodeSelector, nodeSelectorOverride and nodeName are optional, but at least one of them should probably be used
+  #   # Otherwise in multi-node clusters, there's no way to know which Node the XDP Pod will be assigned to
+  #   # and it's unlikely the interface/IP information is correct
+  #   # nodeSelectorOverride is similar to nodeSelector but if specified only those labels will be used for this Pod
+  #   nodeSelector:
+  #     example-label: example-value
+  #   nodeSelectorOverride:
+  #     override-label: override-value
+  #   nodeName: example-node-name
   #   mtu: 1460 # optional, default 1460
   image:
     repository: accelleran/xdpupsappl


### PR DESCRIPTION
@Wielewout a couple of things as I looked at merging this into the main UPS chart:

- I noticed you didn't have JAEGER_AGENT_HOST in the XDP Deployment spec. Do you know if this is no longer valid? I know the CU team switched to OpenTelemetry, but we still have this set in most of our K8S Pods/Deployments for the CU
- I've integrated the two charts, with one values file. My idea was you could specify both XDP interface settings as well as a number of non-XDP UPSs. 
  - Setting `numberOfUpStacks` to 0 would still create any XDP instances explicitly described in the values file, otherwise it will create any "missing" instances, i.e. `numberOfUpStacks - len(xdpUpsInterfaces)` extra instances (min 0 😁)
  -  Maybe it's just better to make it a simple `numberOfUpStacks = number of non-XDP instances` 🤷‍♂️ 
- I switched from a Deployment to a Pod. I'm not entirely sure why we did this previously, but at least it's consistent for now..
- Setting `XDP_OBJECT_FILE` in the Helm chart feels kind of odd, given that its already in a deterministic place at Docker build time. Could this already be set in the Dockerfile?
- Perhaps this is also the case for `HOSTMODE`? Its not quite clear what this does..
- Should we also consider adding node pinning from the list of XDP interfaces? If the Pod isn't pinned to a particular node, the interface details don't make any sense..

I haven't actually tested deploying this yet.. will do that next 😄 